### PR TITLE
OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ AUTHENTICATION_BACKENDS = (
     'allauth.account.auth_backends.AuthenticationBackend',
 )
 
-# ALLAUTh settigs
+# ALLAUTH settings
 ACCOUNT_AUTHENTICATION_METHOD = 'username'
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USERNAME_REQUIRED = True
@@ -48,11 +48,17 @@ ALLAUTH_JANUS_URL = 'https://sso.example.com/oauth2'
 ALLAUTH_JANUS_REDIRECT_PROTOCOL = 'http'
 ALLAUTH_JANUS_REMOTE_LOGOUT = True
 
-# disable default linking by username on signup behavior (if account allready exists)
+# disable default linking by username on signup behavior (if account already exists)
 # ALLAUTH_JANUS_PRE_SOCIAL_CALLBACK=allauth_janus.signals.noop  
 
 SITE_ID = 1
 
+```
+## OIDC
+```
+# Enable usage of OIDC endpoints to retrieve userinfo
+ALLAUTH_JANUS_OIDC = True 
+ALLAUTH_JANUS_CUSTOM_SCOPES = ["openid", "profile", "email"]
 ```
 
 setup your man urls.py` and include allauth urls

--- a/README.md
+++ b/README.md
@@ -58,7 +58,26 @@ SITE_ID = 1
 ```
 # Enable usage of OIDC endpoints to retrieve userinfo
 ALLAUTH_JANUS_OIDC = True 
-ALLAUTH_JANUS_CUSTOM_SCOPES = ["openid", "profile", "email"]
+# The preferred way to configure allauth providers.
+SOCIALACCOUNT_PROVIDERS = {
+    "janus": {
+        # The client id and client secret can be configured via the admin backend (see #first run).
+        # Alternatively they can be configured.
+        "APP": {
+            "client_id": "123",
+            "secret": "456",
+        },
+        # Scope and PKCE can only be configured with this setting.
+        # Default: `openid`
+        "SCOPE": [
+            "openid",
+            "profile",
+            "email"
+        ],
+        # Default: True
+        "OAUTH_PKCE_ENABLED": True
+    }
+}
 ```
 
 setup your man urls.py` and include allauth urls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # installation
 
-`pip install git+https://github.com/smartlgt/janus-allauth-provider@1.1.5#egg=allauth_janus`
+`pip install git+https://github.com/smartlgt/janus-allauth-provider@1.2.1#egg=allauth_janus`
 
 # configuration
 setup your `settings.py`:

--- a/allauth_janus/adapter.py
+++ b/allauth_janus/adapter.py
@@ -2,14 +2,6 @@ from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.account.adapter import DefaultAccountAdapter
 
 
-class Adapter(DefaultSocialAccountAdapter):
-    def pre_social_login(self, request, sociallogin):
-        # using the adapter pre_social_login function is is deprecated, use the signal
-        pass
-
-
-
-
 class AllowNewUsersSocialAccountAdapter(DefaultSocialAccountAdapter):
 
     def is_open_for_signup(self, request, sociallogin):

--- a/allauth_janus/app_settings.py
+++ b/allauth_janus/app_settings.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+# False to not break existing deployments. Uses old custom endpoints when disabled.
+ALLAUTH_JANUS_OIDC = getattr(settings, "ALLAUTH_JANUS_OIDC", False)
+ALLAUTH_JANUS_CUSTOM_SCOPES = getattr(settings, "ALLAUTH_JANUS_CUSTOM_SCOPES", None)
+
+if ALLAUTH_JANUS_OIDC:
+    ALLAUTH_JANUS_PROFILE_URL = settings.ALLAUTH_JANUS_URL + '/o/userinfo/'
+else:
+    ALLAUTH_JANUS_PROFILE_URL = settings.ALLAUTH_JANUS_URL + '/o/profile/'

--- a/allauth_janus/app_settings.py
+++ b/allauth_janus/app_settings.py
@@ -3,6 +3,7 @@ from django.conf import settings
 # False to not break existing deployments. Uses old custom endpoints when disabled.
 ALLAUTH_JANUS_OIDC = getattr(settings, "ALLAUTH_JANUS_OIDC", False)
 ALLAUTH_JANUS_CUSTOM_SCOPES = getattr(settings, "ALLAUTH_JANUS_CUSTOM_SCOPES", None)
+ALLAUTH_JANUS_OAUTH_PKCE_ENABLED = getattr(settings, "ALLAUTH_JANUS_OAUTH_PKCE_ENABLED", False)
 
 if ALLAUTH_JANUS_OIDC:
     ALLAUTH_JANUS_PROFILE_URL = settings.ALLAUTH_JANUS_URL + '/o/userinfo/'

--- a/allauth_janus/app_settings.py
+++ b/allauth_janus/app_settings.py
@@ -2,8 +2,6 @@ from django.conf import settings
 
 # False to not break existing deployments. Uses old custom endpoints when disabled.
 ALLAUTH_JANUS_OIDC = getattr(settings, "ALLAUTH_JANUS_OIDC", False)
-ALLAUTH_JANUS_CUSTOM_SCOPES = getattr(settings, "ALLAUTH_JANUS_CUSTOM_SCOPES", None)
-ALLAUTH_JANUS_OAUTH_PKCE_ENABLED = getattr(settings, "ALLAUTH_JANUS_OAUTH_PKCE_ENABLED", False)
 
 if ALLAUTH_JANUS_OIDC:
     ALLAUTH_JANUS_PROFILE_URL = settings.ALLAUTH_JANUS_URL + '/o/userinfo/'

--- a/allauth_janus/helper.py
+++ b/allauth_janus/helper.py
@@ -1,4 +1,4 @@
-from allauth_janus.app_settings import ALLAUTH_JANUS_OIDC, ALLAUTH_JANUS_CUSTOM_SCOPES
+from allauth_janus.app_settings import ALLAUTH_JANUS_OIDC
 from django.contrib.auth import get_user_model
 
 def janus_sync_user_properties(request, sociallogin):
@@ -92,10 +92,8 @@ def map_extra_data(user, extra_data):
 
 
 def extract_username(data: dict, is_oidc: bool) -> str:
-    if is_oidc and 'profile' in ALLAUTH_JANUS_CUSTOM_SCOPES:
-        # If the `profile` scope is being requested the username should be available.
-        return data['preferred_username']
-    elif is_oidc:
-        return data['sub']
+    if is_oidc:
+        # If the `preferred_username` is available use that. Else use the `sub` claim.
+        return data.get('preferred_username', data['sub'])
     else:
         return data['id']

--- a/allauth_janus/helper.py
+++ b/allauth_janus/helper.py
@@ -2,18 +2,24 @@ from allauth_janus.app_settings import ALLAUTH_JANUS_OIDC, ALLAUTH_JANUS_CUSTOM_
 from django.contrib.auth import get_user_model
 
 def janus_sync_user_properties(request, sociallogin):
-    try:
-        # force connecting of an existing user with the same username
-        # if we remove this, a user that already exists in the local database and was not signed up via janus will
-        # not be able to login and will hang
-        user = get_user_model().objects.get(username=sociallogin.account.uid)
-        if not sociallogin.is_existing:
-            sociallogin.connect(request, user)
+    # There are Django Users and Allauth SocialAccounts.
+    # If a login with Janus has already happened, `sociallogin.user` (User)
+    # and `sociallogin.account` (SocialAccount) will be existing (i.e. already saved) objects.
+    # The User Object is looked up via the SocialAccount.
+    # If it is a new login both will not yet exist in the DB.
+    # But if it is new login (now SocialAccount yet, `sociallogin.is_existing` is false)
+    # but there is a User with the same username in the DB, problems can occur.
+    # A local user (not signed up with Janus) that logs in with Janus has to be connected.
+    # Otherwise, the login will hang.
+    local_user = get_user_model().objects\
+        .filter(username=extract_username(sociallogin.account.extra_data, ALLAUTH_JANUS_OIDC))
+    if not sociallogin.is_existing and local_user:
+        sociallogin.connect(request, local_user.get())
+    elif not sociallogin.is_existing:
+        # This login will go through. Save User Object so that it can be manipulated fully.
+        sociallogin.user.save()
 
-        map_extra_data(user, sociallogin.account.extra_data)
-
-    except get_user_model().DoesNotExist:
-        pass
+    map_extra_data(sociallogin.user, sociallogin.account.extra_data)
 
 
 def map_extra_data(user, extra_data):

--- a/allauth_janus/provider.py
+++ b/allauth_janus/provider.py
@@ -1,4 +1,6 @@
-from allauth_janus.app_settings import ALLAUTH_JANUS_CUSTOM_SCOPES, ALLAUTH_JANUS_OIDC
+from allauth.socialaccount.providers.oauth2.utils import generate_code_challenge
+
+from allauth_janus.app_settings import ALLAUTH_JANUS_CUSTOM_SCOPES, ALLAUTH_JANUS_OIDC, ALLAUTH_JANUS_OAUTH_PKCE_ENABLED
 
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
@@ -27,6 +29,12 @@ class JanusProvider(OAuth2Provider):
         if dynamic_scope:
             scope.extend(dynamic_scope.split(","))
         return scope
+
+    def get_pkce_params(self):
+        if ALLAUTH_JANUS_OAUTH_PKCE_ENABLED or self.pkce_enabled_default:
+            pkce_code_params = generate_code_challenge()
+            return pkce_code_params
+        return {}
 
     # The `uid` and `username` must be the same.
     # The actual user data is written to the User model in `map_extra_data`.

--- a/allauth_janus/provider.py
+++ b/allauth_janus/provider.py
@@ -1,6 +1,4 @@
-from allauth.socialaccount.providers.oauth2.utils import generate_code_challenge
-
-from allauth_janus.app_settings import ALLAUTH_JANUS_CUSTOM_SCOPES, ALLAUTH_JANUS_OIDC, ALLAUTH_JANUS_OAUTH_PKCE_ENABLED
+from allauth_janus.app_settings import ALLAUTH_JANUS_OIDC
 
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
@@ -21,20 +19,6 @@ class JanusProvider(OAuth2Provider):
 
     def get_default_scope(self):
         return ['openid']
-
-    def get_scope(self, request):
-        # Use custom scopes if set else use default.
-        scope = ALLAUTH_JANUS_CUSTOM_SCOPES or self.get_default_scope()
-        dynamic_scope = request.GET.get("scope", None)
-        if dynamic_scope:
-            scope.extend(dynamic_scope.split(","))
-        return scope
-
-    def get_pkce_params(self):
-        if ALLAUTH_JANUS_OAUTH_PKCE_ENABLED or self.pkce_enabled_default:
-            pkce_code_params = generate_code_challenge()
-            return pkce_code_params
-        return {}
 
     # The `uid` and `username` must be the same.
     # The actual user data is written to the User model in `map_extra_data`.

--- a/allauth_janus/views.py
+++ b/allauth_janus/views.py
@@ -1,3 +1,5 @@
+from allauth_janus.app_settings import ALLAUTH_JANUS_PROFILE_URL
+
 import requests
 
 from allauth.socialaccount.providers.oauth2.views import (
@@ -14,7 +16,7 @@ class JanusOAuth2Adapter(OAuth2Adapter):
     provider_id = JanusProvider.id
     access_token_url = settings.ALLAUTH_JANUS_URL + '/o/token/'
     authorize_url = settings.ALLAUTH_JANUS_URL + '/o/authorize/'
-    profile_url = settings.ALLAUTH_JANUS_URL + '/o/profile/'
+    profile_url = ALLAUTH_JANUS_PROFILE_URL
     supports_state = True
     redirect_uri_protocol = settings.ALLAUTH_JANUS_REDIRECT_PROTOCOL
 

--- a/allauth_janus/views.py
+++ b/allauth_janus/views.py
@@ -21,7 +21,7 @@ class JanusOAuth2Adapter(OAuth2Adapter):
     def complete_login(self, request, app, token, **kwargs):
         response = requests.get(
             self.profile_url,
-            params={'access_token': token})
+            headers={"Authorization": f"Bearer {token}"})
         extra_data = response.json()
 
         return self.get_provider().sociallogin_from_response(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = VERSION = (1, 2, 0)
+__version__ = VERSION = (1, 2, 1)
 
 
 setup(
@@ -10,7 +10,7 @@ setup(
     description="Janus provider is a allauth provider for authentication with the django janus SSO.",
     author="Daniel Leinfelder",
     author_email="daniel@smart-lgt.com",
-    url="http://github.com/smartlgt/janus-allauth-provider",
+    url="https://github.com/smartlgt/janus-allauth-provider",
     zip_safe=False,
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
Configure custom scopes and use OIDC endpoints in Janus introduced by https://github.com/smartlgt/django-janus/pull/7. Some code cleanup. Use Authorization header instead of Get Parameter.